### PR TITLE
Include the generated patch in the output

### DIFF
--- a/probes/hasDangerousWorkflowScriptInjection/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/probes/hasDangerousWorkflowScriptInjection/patch"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
 
@@ -62,6 +63,8 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 				LineStart: &e.File.Offset,
 				Snippet:   &e.File.Snippet,
 			})
+			patch := patch.GeneratePatch(e.File)
+			f.WithPatch(&patch)
 			findings = append(findings, *f)
 		}
 	}

--- a/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
@@ -1,0 +1,33 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/ossf/scorecard/v4/checker"
+)
+
+// TODO: Receive the dangerous workflow as parameter
+func GeneratePatch(f checker.File) string {
+	//TODO: Implement
+	// example:
+	// type scriptInjection
+	// path {.github/workflows/active-elastic-job~active-elastic-job~build.yml  github.head_ref  91 0 0 1}
+	// snippet github.head_ref
+	src := "message=$(echo \"${{ github.event.head_commit.message }}\" | tail -n +3)"
+	dst := "message=$(echo $COMMIT | tail -n +3)"
+
+	return cmp.Diff(src, dst)
+}

--- a/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
@@ -15,19 +15,41 @@
 package patch
 
 import (
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/ossf/scorecard/v4/checker"
 )
 
+func parseDiff(diff string) string {
+	i := strings.Index(diff, "\"\"\"\n")
+	if i == -1 {
+		return diff
+	}
+	//remove everything before """\n
+	diff = diff[i+4:]
+	i = strings.LastIndex(diff, "\"\"\"")
+	if i == -1 {
+		return diff
+	}
+	//remove everything after \n  \t"""
+	return diff[:i]
+}
+
 // TODO: Receive the dangerous workflow as parameter
 func GeneratePatch(f checker.File) string {
-	//TODO: Implement
+	// TODO: Implement
 	// example:
 	// type scriptInjection
 	// path {.github/workflows/active-elastic-job~active-elastic-job~build.yml  github.head_ref  91 0 0 1}
 	// snippet github.head_ref
-	src := "message=$(echo \"${{ github.event.head_commit.message }}\" | tail -n +3)"
-	dst := "message=$(echo $COMMIT | tail -n +3)"
-
-	return cmp.Diff(src, dst)
+	src := `asasas
+hello """ola"""
+	message=$(echo "${{ github.event.head_commit.message }}" | tail -n +3)
+adios`
+	dst := `asasas
+hello """ola"""
+	message=$(echo $COMMIT | tail -n +3)
+adios`
+	return parseDiff(cmp.Diff(src, dst))
 }

--- a/probes/hasDangerousWorkflowScriptInjection/patch/impl_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/impl_test.go
@@ -1,0 +1,15 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch

--- a/probes/hasDangerousWorkflowScriptInjection/patch/parse_workflow.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/parse_workflow.go
@@ -1,0 +1,15 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch

--- a/probes/hasDangerousWorkflowScriptInjection/patch/parse_workflow_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/parse_workflow_test.go
@@ -1,0 +1,15 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch


### PR DESCRIPTION
TODO:

- [x] Handle the diff to not return a strings.Join in the beggining

We can decide to merge it anyway while I work on the topic above. 

It is now currently working with
`go run main.go --local ../../identify-repo-ctx/ --probes hasDangerousWorkflowScriptInjection --format=probe | jq`

![image](https://github.com/joycebrum/scorecard/assets/22223372/1d179734-6f66-46b6-98d9-a1533f4aa198)
