### PR TITLE
Patch dangerous workflows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,6 +152,7 @@ require (
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20240117034632-964b1d53ca6c h1:WIMs00AR+1aVkUPrzfO3aZSPM7UHooevjnJHGSstgmQ=

--- a/probes/hasDangerousWorkflowScriptInjection/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/impl.go
@@ -51,35 +51,39 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	var findings []finding.Finding
 	var curr string
-	var content []byte
+	var content string
 	localPath := raw.Metadata.Metadata["localPath"]
-	for _, e := range r.Workflows {
-		e := e
-		if e.Type == checker.DangerousWorkflowScriptInjection {
-			f, err := finding.NewWith(fs, Probe,
-				fmt.Sprintf("script injection with untrusted input '%v'", e.File.Snippet),
-				nil, finding.OutcomeNegative)
-			if err != nil {
-				return nil, Probe, fmt.Errorf("create finding: %w", err)
-			}
-			f = f.WithLocation(&finding.Location{
-				Path:      e.File.Path,
-				Type:      e.File.Type,
-				LineStart: &e.File.Offset,
-				Snippet:   &e.File.Snippet,
-			})
-
-			wp := path.Join(localPath, e.File.Path)
-			if curr != wp {
-				curr = wp
-				content, err = os.ReadFile(wp)
-			}
-			if err == nil {
-				findingPatch := patch.GeneratePatch(e.File, content)
-				f.WithPatch(&findingPatch)
-			}
-			findings = append(findings, *f)
+	for _, w := range r.Workflows {
+		w := w
+		if w.Type != checker.DangerousWorkflowScriptInjection {
+			continue
 		}
+
+		f, err := finding.NewWith(fs, Probe,
+			fmt.Sprintf("script injection with untrusted input '%v'", w.File.Snippet),
+			nil, finding.OutcomeNegative)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		f = f.WithLocation(&finding.Location{
+			Path:      w.File.Path,
+			Type:      w.File.Type,
+			LineStart: &w.File.Offset,
+			Snippet:   &w.File.Snippet,
+		})
+
+		wp := path.Join(localPath, w.File.Path)
+		if curr != wp {
+			curr = wp
+			var c []byte
+			c, err = os.ReadFile(wp)
+			content = string(c)
+		}
+		if err == nil {
+			findingPatch := patch.GeneratePatch(w.File, content)
+			f.WithPatch(&findingPatch)
+		}
+		findings = append(findings, *f)
 	}
 	if len(findings) == 0 {
 		return positiveOutcome()

--- a/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
@@ -30,107 +30,113 @@ package patch
 import (
 	"fmt"
 	"os"
-	"path"
 	"regexp"
 	"slices"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/ossf/scorecard/v4/checker"
 	sce "github.com/ossf/scorecard/v4/errors"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
 )
 
 const (
 	assumedIndent = 2
 )
 
-func parseDiff(diff string) string {
-	i := strings.Index(diff, "\"\"\"\n")
-	if i == -1 {
-		return diff
-	}
-
-	diff = diff[i+4:]
-	i = strings.LastIndex(diff, "\"\"\"")
-	if i == -1 {
-		return diff
-	}
-
-	return diff[:i]
-}
-
-// Placeholder function that should receive the file of a workflow and
-// return the end result of the Script Injection patch
-//
-// TODO: Receive the dangerous workflow as parameter.
 func GeneratePatch(f checker.File) string {
-	// TODO: Implement
-	// example:
-	// type scriptInjection
-	// path {.github/workflows/active-elastic-job~active-elastic-job~build.yml  github.head_ref  91 0 0 1}
-	// snippet github.head_ref
-
 	// for testing, while we figure out how to get the full path
-	path := path.Join("/home/pnacht_google_com/temp_test", f.Path)
+	// path := path.Join("/home/pnacht_google_com/temp_test", f.Path)
+	path := f.Path
+	unsafeVar := strings.Trim(f.Snippet, " ")
+	runCmdIndex := f.Offset - 1
 
-	blob, err := os.ReadFile(path)
+	ow, err := os.ReadFile(path)
 
 	if err != nil {
 		return ""
 	}
+	originalWorkflow := string(ow)
 
-	lines := strings.Split(string(blob), "\n")
+	lines := strings.Split(string(originalWorkflow), "\n")
 
+	unsafePattern, envvar, err := getReplacementRegexAndEnvvarName(unsafeVar)
+	if err != nil {
+		fmt.Printf("%v", err)
+	}
+
+	replaceUnsafeVarWithEnvvar(lines, unsafePattern, envvar, runCmdIndex)
+
+	lines, ok := addEnvvarsToGlobalEnv(lines, envvar, unsafeVar)
+	if !ok {
+		return ""
+	}
+
+	fixedWorkflow := strings.Join(lines, "\n")
+
+	return getDiff(f.Path, path, originalWorkflow, fixedWorkflow)
+}
+
+func getDiff(displayPath, fullPath, original, patched string) string {
+	// gets the changes as a git-diff. Following the standard used in git diff, the
+	// path to the "old" version is prefixed with a/, and the "new" with b/:
+	//
+	// --- a/.github/workflows/foo.yml
+	// +++ b/.github/workflows/foo.yml
+	// @@ -42,13 + 42,22 @@
+	// ...
+	edits := myers.ComputeEdits(span.URIFromPath(fullPath), original, patched)
+	aPath := "a/" + displayPath
+	bPath := "b/" + displayPath
+	return fmt.Sprint(gotextdiff.ToUnified(aPath, bPath, original, edits))
+}
+
+func addEnvvarsToGlobalEnv(lines []string, envvar string, unsafeVar string) ([]string, bool) {
 	globalIndentation, ok := findGlobalIndentation(lines)
 
 	if !ok {
 		// invalid workflow, could not determine global indentation
-		return ""
+		return nil, false
 	}
 
 	envPos, envvarIndent, exists := findExistingEnv(lines, globalIndentation)
 
 	if !exists {
-		envPos, ok = findNewEnvPos(lines, globalIndentation)
-
+		lines, envPos, ok = addNewGlobalEnv(lines, globalIndentation)
 		if !ok {
-			// invalid workflow, could not determine location for new environment
-			return ""
+			return nil, ok
 		}
 
-		label := strings.Repeat(" ", globalIndentation) + "env:"
-		lines = slices.Insert(lines, envPos, []string{label, ""}...)
-		envPos += 1 // position now points to `env:`, insert variables below it
+		// position now points to `env:`, insert variables below it
+		envPos += 1
 		envvarIndent = globalIndentation + assumedIndent
 	}
+	envvarDefinition := fmt.Sprintf("%s: %s", envvar, unsafeVar)
+	lines = slices.Insert(lines, envPos,
+		strings.Repeat(" ", envvarIndent)+envvarDefinition)
+	return lines, ok
+}
 
-	envvar, err := convertUnsafeVarToEnvvar(f.Snippet)
-	if err != nil {
-		fmt.Printf("%v", err)
+func addNewGlobalEnv(lines []string, globalIndentation int) ([]string, int, bool) {
+	envPos, ok := findNewEnvPos(lines, globalIndentation)
+
+	if !ok {
+		// invalid workflow, could not determine location for new environment
+		return nil, envPos, ok
 	}
-	lines = slices.Insert(lines, envPos, strings.Repeat(" ", envvarIndent)+envvar)
 
-	for _, line := range lines {
-		fmt.Println(line)
-	}
-
-	src := `asasas
-hello """ola"""
-	message=$(echo "${{ github.event.head_commit.message }}" | tail -n +3)
-adios`
-	dst := `asasas
-hello """ola"""
-	message=$(echo $COMMIT | tail -n +3)
-adios`
-	return parseDiff(cmp.Diff(src, dst))
+	label := strings.Repeat(" ", globalIndentation) + "env:"
+	lines = slices.Insert(lines, envPos, []string{label, ""}...)
+	return lines, envPos, ok
 }
 
 func findGlobalIndentation(lines []string) (int, bool) {
 	r := regexp.MustCompile(`^\W*on:`)
 	for _, line := range lines {
 		if r.MatchString(line) {
-			return len(line) - len(strings.TrimLeft(line, " ")), true
+			return getIndent(line), true
 		}
 	}
 
@@ -157,7 +163,7 @@ func findExistingEnv(lines []string, globalIndent int) (int, int, bool) {
 	}
 
 	i++ // move to line after `env:`
-	envvarIndent := len(lines[i]) - len(strings.TrimLeft(lines[i], " "))
+	envvarIndent := getIndent(lines[i])
 	// regex to detect envvars belonging to the global `env:` block
 	envvarRegex := regexp.MustCompile(indent + `\W+[^#]`)
 	for ; i < num_lines; i++ {
@@ -184,40 +190,75 @@ func findNewEnvPos(lines []string, globalIndent int) (int, bool) {
 	return -1, false
 }
 
-var unsafeVarToEnvvar = map[*regexp.Regexp]string{
-	regexp.MustCompile(`issue\.title`):                             "ISSUE_TITLE",
-	regexp.MustCompile(`issue\.body`):                              "ISSUE_BODY",
-	regexp.MustCompile(`pull_request\.title`):                      "PR_TITLE",
-	regexp.MustCompile(`pull_request\.body`):                       "PR_BODY",
-	regexp.MustCompile(`comment\.body`):                            "COMMENT_BODY",
-	regexp.MustCompile(`review\.body`):                             "REVIEW_BODY",
-	regexp.MustCompile(`review_comment\.body`):                     "REVIEW_COMMENT_BODY",
-	regexp.MustCompile(`pages.*\.page_name`):                       "PAGE_NAME",
-	regexp.MustCompile(`commits.*\.message`):                       "COMMIT_MESSAGE",
-	regexp.MustCompile(`head_commit\.message`):                     "COMMIT_MESSAGE",
-	regexp.MustCompile(`head_commit\.author\.email`):               "AUTHOR_EMAIL",
-	regexp.MustCompile(`head_commit\.author\.name`):                "AUTHOR_NAME",
-	regexp.MustCompile(`commits.*\.author\.email`):                 "AUTHOR_EMAIL",
-	regexp.MustCompile(`commits.*\.author\.name`):                  "AUTHOR_NAME",
-	regexp.MustCompile(`pull_request\.head\.ref`):                  "PR_HEAD_REF",
-	regexp.MustCompile(`pull_request\.head\.label`):                "PR_HEAD_LABEL",
-	regexp.MustCompile(`pull_request\.head\.repo\.default_branch`): "PR_DEFAULT_BRANCH",
-	regexp.MustCompile(`github\.head_ref`):                         "HEAD_REF",
+type unsafePattern struct {
+	envvarName   string
+	idRegex      *regexp.Regexp
+	replaceRegex *regexp.Regexp
 }
 
-func convertUnsafeVarToEnvvar(unsafeVar string) (string, error) {
-	for regex, envvar := range unsafeVarToEnvvar {
-		if regex.MatchString(unsafeVar) {
-			return fmt.Sprintf("%s: %s", envvar, unsafeVar), nil
+func newUnsafePattern(e, p string) unsafePattern {
+	return unsafePattern{
+		envvarName:   e,
+		idRegex:      regexp.MustCompile(p),
+		replaceRegex: regexp.MustCompile(`{{\W*.*?` + p + `.*?\W*}}`),
+	}
+}
+
+var unsafePatterns = []unsafePattern{
+	newUnsafePattern("AUTHOR_EMAIL", `github\.event\.commits.*?\.author\.email`),
+	newUnsafePattern("AUTHOR_EMAIL", `github\.event\.head_commit\.author\.email`),
+	newUnsafePattern("AUTHOR_NAME", `github\.event\.commits.*?\.author\.name`),
+	newUnsafePattern("AUTHOR_NAME", `github\.event\.head_commit\.author\.name`),
+	newUnsafePattern("COMMENT_BODY", `github\.event\.comment\.body`),
+	newUnsafePattern("COMMIT_MESSAGE", `github\.event\.commits.*?\.message`),
+	newUnsafePattern("COMMIT_MESSAGE", `github\.event\.head_commit\.message`),
+	newUnsafePattern("ISSUE_BODY", `github\.event\.issue\.body`),
+	newUnsafePattern("ISSUE_TITLE", `github\.event\.issue\.title`),
+	newUnsafePattern("PAGE_NAME", `github\.event\.pages.*?\.page_name`),
+	newUnsafePattern("PR_BODY", `github\.event\.pull_request\.body`),
+	newUnsafePattern("PR_DEFAULT_BRANCH", `github\.event\.pull_request\.head\.repo\.default_branch`),
+	newUnsafePattern("PR_HEAD_LABEL", `github\.event\.pull_request\.head\.label`),
+	newUnsafePattern("PR_HEAD_REF", `github\.event\.pull_request\.head\.ref`),
+	newUnsafePattern("PR_TITLE", `github\.event\.pull_request\.title`),
+	newUnsafePattern("REVIEW_BODY", `github\.event\.review\.body`),
+	newUnsafePattern("REVIEW_COMMENT_BODY", `github\.event\.review_comment\.body`),
+
+	newUnsafePattern("HEAD_REF", `github\.head_ref`),
+}
+
+func getReplacementRegexAndEnvvarName(unsafeVar string) (*regexp.Regexp, string, error) {
+	for _, p := range unsafePatterns {
+		if p.idRegex.MatchString(unsafeVar) {
+			return p.replaceRegex, p.envvarName, nil
 		}
 	}
-	return "", sce.WithMessage(sce.ErrScorecardInternal,
+	return nil, "", sce.WithMessage(sce.ErrScorecardInternal,
 		fmt.Sprintf(
 			"Detected unsafe variable '%s', but could not find a compatible envvar name",
 			unsafeVar))
 }
 
-func replaceUnsafeVarWithEnvvar(line string, unsafeVar string, envvar string) string {
-	r := regexp.MustCompile(`${{\W*` + unsafeVar + `\W*}}`)
-	return r.ReplaceAllString(line, "$"+envvar)
+func replaceUnsafeVarWithEnvvar(lines []string, replaceRegex *regexp.Regexp, envvar string, runIndex uint) {
+	runIndent := getIndent(lines[runIndex])
+	for i := int(runIndex); i < len(lines) && isParentLevelIndent(lines[i], runIndent); i++ {
+		lines[i] = replaceRegex.ReplaceAllString(lines[i], envvar)
+	}
+}
+
+func getIndent(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " -"))
+}
+
+func isBlankOrComment(line string) bool {
+	blank := regexp.MustCompile(`^\W*$`)
+	comment := regexp.MustCompile(`^\W*#`)
+
+	return blank.MatchString(line) || comment.MatchString(line)
+}
+
+func isParentLevelIndent(line string, parentIndent int) bool {
+	if isBlankOrComment(line) {
+		return false
+	}
+	return getIndent(line) >= parentIndent
 }

--- a/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/impl.go
@@ -12,14 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+TODO
+  - Detects the end of the existing envvars at the first line that does not declare an
+    envvar. This can lead to weird insertion positions if there is a comment in the
+    middle of the `env:` block.
+  - Tried performing a "dumber" implementation than the Python script, with less
+    "parsing" of the workflow. However, the location given by f.Offset isn't precise
+    enough. It only marks the start of the `run:` command, not the line where the
+    variable is actually used. Will therefore need to, at least, parse the `run`
+    command to replace all the instances of the unsafe variable. This means we can
+    have multiple identical remediations if the same variable is used multiple times
+    in the same step... that's just life.
+*/
 package patch
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/ossf/scorecard/v4/checker"
+	sce "github.com/ossf/scorecard/v4/errors"
+)
+
+const (
+	assumedIndent = 2
 )
 
 func parseDiff(diff string) string {
@@ -37,10 +60,164 @@ func parseDiff(diff string) string {
 	return diff[:i]
 }
 
-func GeneratePatch(f checker.File, content []byte) string {
-	src := string(content)
-	// TODO: call fix method
-	dst := src + "\n    # random change for testing patch diff"
+// Placeholder function that should receive the file of a workflow and
+// return the end result of the Script Injection patch
+//
+// TODO: Receive the dangerous workflow as parameter.
+func GeneratePatch(f checker.File) string {
+	// TODO: Implement
+	// example:
+	// type scriptInjection
+	// path {.github/workflows/active-elastic-job~active-elastic-job~build.yml  github.head_ref  91 0 0 1}
+	// snippet github.head_ref
 
+	// for testing, while we figure out how to get the full path
+	path := path.Join("/home/pnacht_google_com/temp_test", f.Path)
+
+	blob, err := os.ReadFile(path)
+
+	if err != nil {
+		return ""
+	}
+
+	lines := strings.Split(string(blob), "\n")
+
+	globalIndentation, ok := findGlobalIndentation(lines)
+
+	if !ok {
+		// invalid workflow, could not determine global indentation
+		return ""
+	}
+
+	envPos, envvarIndent, exists := findExistingEnv(lines, globalIndentation)
+
+	if !exists {
+		envPos, ok = findNewEnvPos(lines, globalIndentation)
+
+		if !ok {
+			// invalid workflow, could not determine location for new environment
+			return ""
+		}
+
+		label := strings.Repeat(" ", globalIndentation) + "env:"
+		lines = slices.Insert(lines, envPos, []string{label, ""}...)
+		envPos += 1 // position now points to `env:`, insert variables below it
+		envvarIndent = globalIndentation + assumedIndent
+	}
+
+	envvar, err := convertUnsafeVarToEnvvar(f.Snippet)
+	if err != nil {
+		fmt.Printf("%v", err)
+	}
+	lines = slices.Insert(lines, envPos, strings.Repeat(" ", envvarIndent)+envvar)
+
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+
+	src := `asasas
+hello """ola"""
+	message=$(echo "${{ github.event.head_commit.message }}" | tail -n +3)
+adios`
+	dst := `asasas
+hello """ola"""
+	message=$(echo $COMMIT | tail -n +3)
+adios`
 	return parseDiff(cmp.Diff(src, dst))
+}
+
+func findGlobalIndentation(lines []string) (int, bool) {
+	r := regexp.MustCompile(`^\W*on:`)
+	for _, line := range lines {
+		if r.MatchString(line) {
+			return len(line) - len(strings.TrimLeft(line, " ")), true
+		}
+	}
+
+	return -1, false
+}
+
+func findExistingEnv(lines []string, globalIndent int) (int, int, bool) {
+	num_lines := len(lines)
+	indent := strings.Repeat(" ", globalIndent)
+
+	// regex to detect the global `env:` block
+	labelRegex := regexp.MustCompile(indent + "env:")
+	i := 0
+	for i = 0; i < num_lines; i++ {
+		line := lines[i]
+		if labelRegex.MatchString(line) {
+			break
+		}
+	}
+
+	if i >= num_lines-1 {
+		// there must be at least one more line
+		return -1, -1, false
+	}
+
+	i++ // move to line after `env:`
+	envvarIndent := len(lines[i]) - len(strings.TrimLeft(lines[i], " "))
+	// regex to detect envvars belonging to the global `env:` block
+	envvarRegex := regexp.MustCompile(indent + `\W+[^#]`)
+	for ; i < num_lines; i++ {
+		line := lines[i]
+		if !envvarRegex.MatchString(line) {
+			// no longer declaring envvars
+			break
+		}
+	}
+
+	return i, envvarIndent, true
+}
+
+func findNewEnvPos(lines []string, globalIndent int) (int, bool) {
+	// the new env is added right before `jobs:`
+	indent := strings.Repeat(" ", globalIndent)
+	r := regexp.MustCompile(indent + "jobs:")
+	for i, line := range lines {
+		if r.MatchString(line) {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
+var unsafeVarToEnvvar = map[*regexp.Regexp]string{
+	regexp.MustCompile(`issue\.title`):                             "ISSUE_TITLE",
+	regexp.MustCompile(`issue\.body`):                              "ISSUE_BODY",
+	regexp.MustCompile(`pull_request\.title`):                      "PR_TITLE",
+	regexp.MustCompile(`pull_request\.body`):                       "PR_BODY",
+	regexp.MustCompile(`comment\.body`):                            "COMMENT_BODY",
+	regexp.MustCompile(`review\.body`):                             "REVIEW_BODY",
+	regexp.MustCompile(`review_comment\.body`):                     "REVIEW_COMMENT_BODY",
+	regexp.MustCompile(`pages.*\.page_name`):                       "PAGE_NAME",
+	regexp.MustCompile(`commits.*\.message`):                       "COMMIT_MESSAGE",
+	regexp.MustCompile(`head_commit\.message`):                     "COMMIT_MESSAGE",
+	regexp.MustCompile(`head_commit\.author\.email`):               "AUTHOR_EMAIL",
+	regexp.MustCompile(`head_commit\.author\.name`):                "AUTHOR_NAME",
+	regexp.MustCompile(`commits.*\.author\.email`):                 "AUTHOR_EMAIL",
+	regexp.MustCompile(`commits.*\.author\.name`):                  "AUTHOR_NAME",
+	regexp.MustCompile(`pull_request\.head\.ref`):                  "PR_HEAD_REF",
+	regexp.MustCompile(`pull_request\.head\.label`):                "PR_HEAD_LABEL",
+	regexp.MustCompile(`pull_request\.head\.repo\.default_branch`): "PR_DEFAULT_BRANCH",
+	regexp.MustCompile(`github\.head_ref`):                         "HEAD_REF",
+}
+
+func convertUnsafeVarToEnvvar(unsafeVar string) (string, error) {
+	for regex, envvar := range unsafeVarToEnvvar {
+		if regex.MatchString(unsafeVar) {
+			return fmt.Sprintf("%s: %s", envvar, unsafeVar), nil
+		}
+	}
+	return "", sce.WithMessage(sce.ErrScorecardInternal,
+		fmt.Sprintf(
+			"Detected unsafe variable '%s', but could not find a compatible envvar name",
+			unsafeVar))
+}
+
+func replaceUnsafeVarWithEnvvar(line string, unsafeVar string, envvar string) string {
+	r := regexp.MustCompile(`${{\W*` + unsafeVar + `\W*}}`)
+	return r.ReplaceAllString(line, "$"+envvar)
 }

--- a/probes/hasDangerousWorkflowScriptInjection/patch/impl_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/impl_test.go
@@ -15,7 +15,11 @@
 package patch
 
 import (
+	"fmt"
 	"os"
+	"path"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,131 +30,185 @@ import (
 func Test_GeneratePatch(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name             string
-		inputFilepath    string
-		expectedFilepath string
-		// err      error
+		name     string
+		file     checker.File
+		diffPath string
 	}{
 		// Extracted from real Angular fix: https://github.com/angular/angular/pull/51026/files
 		{
-			name:             "Real Example 1",
-			inputFilepath:    "realExample1.yaml",
-			expectedFilepath: "realExample1_fixed.yaml",
+			name: "Real Example 1",
+			file: checker.File{
+				Path:    "realExample1.yaml",
+				Snippet: " github.event.comment.body ",
+				Offset:  42,
+			},
+			diffPath: "realExample1.diff",
 		},
-		// Inspired on a real fix: https://github.com/googleapis/google-cloud-go/pull/9011/files
-		{
-			name:             "Real Example 2",
-			inputFilepath:    "realExample2.yaml",
-			expectedFilepath: "realExample2_fixed.yaml",
-		},
-		// Inspired from a real lit/lit fix: https://github.com/lit/lit/pull/3669/files
-		{
-			name:             "Real Example 3",
-			inputFilepath:    "realExample3.yaml",
-			expectedFilepath: "realExample3_fixed.yaml",
-		},
-		{
-			name:             "Test all (or most) types of user input that should be detected",
-			inputFilepath:    "allKindsOfUserInput.yaml",
-			expectedFilepath: "allKindsOfUserInput_fixed.yaml",
-		},
-		{
-			name:             "User's input is assigned to a variable before used",
-			inputFilepath:    "userInputAssignedToVariable.yaml",
-			expectedFilepath: "userInputAssignedToVariable_fixed.yaml",
-		},
-		{
-			name:             "Two incidences in different jobs",
-			inputFilepath:    "twoInjectionsDifferentJobs.yaml",
-			expectedFilepath: "twoInjectionsDifferentJobs_fixed.yaml",
-		},
-		{
-			name:             "Two incidences in same job",
-			inputFilepath:    "twoInjectionsSameJob.yaml",
-			expectedFilepath: "twoInjectionsSameJob_fixed.yaml",
-		},
-		{
-			name:             "Two incidences in same step",
-			inputFilepath:    "twoInjectionsSameStep.yaml",
-			expectedFilepath: "twoInjectionsSameStep_fixed.yaml",
-		},
-		{
-			name:             "Reuse existent workflow level env var, if has the same name we'd give",
-			inputFilepath:    "reuseWorkflowLevelEnvVars.yaml",
-			expectedFilepath: "reuseWorkflowLevelEnvVars_fixed.yaml",
-		},
-		// Test currently failing because we don't look for existent env vars pointing to the same content.
-		// Once proper behavior is implemented, enable this test
+		// // Inspired on a real fix: https://github.com/googleapis/google-cloud-go/pull/9011/files
 		// {
-		// 	name:             "Reuse existent workflow level env var, if it DOES NOT have the same name we'd give",
-		// 	inputFilepath:    "reuseEnvVarWithDiffName.yaml",
-		// 	expectedFilepath: "reuseEnvVarWithDiffName_fixed.yaml",
+		// 	name:             "Real Example 2",
+		// 	inputFilepath:    "realExample2.yaml",
+		// 	expectedFilepath: "realExample2_fixed.yaml",
 		// },
+		// // Inspired from a real lit/lit fix: https://github.com/lit/lit/pull/3669/files
+		// {
+		// 	name:             "Real Example 3",
+		// 	inputFilepath:    "realExample3.yaml",
+		// 	expectedFilepath: "realExample3_fixed.yaml",
+		// },
+		// {
+		// 	name:             "Test all (or most) types of user input that should be detected",
+		// 	inputFilepath:    "allKindsOfUserInput.yaml",
+		// 	expectedFilepath: "allKindsOfUserInput_fixed.yaml",
+		// },
+		// {
+		// 	name:             "User's input is assigned to a variable before used",
+		// 	inputFilepath:    "userInputAssignedToVariable.yaml",
+		// 	expectedFilepath: "userInputAssignedToVariable_fixed.yaml",
+		// },
+		// {
+		// 	name:             "Two incidences in different jobs",
+		// 	inputFilepath:    "twoInjectionsDifferentJobs.yaml",
+		// 	expectedFilepath: "twoInjectionsDifferentJobs_fixed.yaml",
+		// },
+		// {
+		// 	name:             "Two incidences in same job",
+		// 	inputFilepath:    "twoInjectionsSameJob.yaml",
+		// 	expectedFilepath: "twoInjectionsSameJob_fixed.yaml",
+		// },
+		// {
+		// 	name:             "Two incidences in same step",
+		// 	inputFilepath:    "twoInjectionsSameStep.yaml",
+		// 	expectedFilepath: "twoInjectionsSameStep_fixed.yaml",
+		// },
+		// {
+		// 	name:             "Reuse existent workflow level env var, if has the same name we'd give",
+		// 	inputFilepath:    "reuseWorkflowLevelEnvVars.yaml",
+		// 	expectedFilepath: "reuseWorkflowLevelEnvVars_fixed.yaml",
+		// },
+		// // Test currently failing because we don't look for existent env vars pointing to the same content.
+		// // Once proper behavior is implemented, enable this test
+		// // {
+		// // 	name:             "Reuse existent workflow level env var, if it DOES NOT have the same name we'd give",
+		// // 	inputFilepath:    "reuseEnvVarWithDiffName.yaml",
+		// // 	expectedFilepath: "reuseEnvVarWithDiffName_fixed.yaml",
+		// // },
 
-		// Test currently failing because we don't look for existent env vars on smaller scopes -- job-level or step-level.
-		// In this case, we're always creating a new workflow-level env var. Note that this could lead to creation of env vars shadowed
-		// by the ones in smaller scope.
-		// Once proper behavior is implemented, enable this test
+		// // Test currently failing because we don't look for existent env vars on smaller scopes -- job-level or step-level.
+		// // In this case, we're always creating a new workflow-level env var. Note that this could lead to creation of env vars shadowed
+		// // by the ones in smaller scope.
+		// // Once proper behavior is implemented, enable this test
+		// // {
+		// // 	name:             "Reuse env var already existent on smaller scope, it converts case of same or different names",
+		// // 	inputFilepath:    "reuseEnvVarSmallerScope.yaml",
+		// // 	expectedFilepath: "reuseEnvVarSmallerScope_fixed.yaml",
+		// // },
 		// {
-		// 	name:             "Reuse env var already existent on smaller scope, it converts case of same or different names",
-		// 	inputFilepath:    "reuseEnvVarSmallerScope.yaml",
-		// 	expectedFilepath: "reuseEnvVarSmallerScope_fixed.yaml",
+		// 	name:             "4-spaces indentation is kept the same",
+		// 	inputFilepath:    "fourSpacesIndentationExistentEnvVar.yaml",
+		// 	expectedFilepath: "fourSpacesIndentationExistentEnvVar_fixed.yaml",
 		// },
-		{
-			name:             "4-spaces indentation is kept the same",
-			inputFilepath:    "fourSpacesIndentationExistentEnvVar.yaml",
-			expectedFilepath: "fourSpacesIndentationExistentEnvVar_fixed.yaml",
-		},
-		{
-			name:             "Crazy but valid indentation is kept the same",
-			inputFilepath:    "crazyButValidIndentation.yaml",
-			expectedFilepath: "crazyButValidIndentation_fixed.yaml",
-		},
-		{
-			name:             "Newline on EOF is kept",
-			inputFilepath:    "newlineOnEOF.yaml",
-			expectedFilepath: "newlineOnEOF_fixed.yaml",
-		},
-		// Test currently failing due to lack of style awareness. Currently we always add a blankline after
-		// the env block.
-		// Once proper behavior is implemented, enable this test.
 		// {
-		// 	name:             "Keep style if file doesnt use blank lines between blocks",
-		// 	inputFilepath:    "noLineBreaksBetweenBlocks.yaml",
-		// 	expectedFilepath: "noLineBreaksBetweenBlocks_fixed.yaml",
+		// 	name:             "Crazy but valid indentation is kept the same",
+		// 	inputFilepath:    "crazyButValidIndentation.yaml",
+		// 	expectedFilepath: "crazyButValidIndentation_fixed.yaml",
 		// },
-		{
-			name:             "Ignore if user input regex is just part of a comment",
-			inputFilepath:    "ignorePatternInsideComments.yaml",
-			expectedFilepath: "ignorePatternInsideComments.yaml",
-		},
+		// {
+		// 	name:             "Newline on EOF is kept",
+		// 	inputFilepath:    "newlineOnEOF.yaml",
+		// 	expectedFilepath: "newlineOnEOF_fixed.yaml",
+		// },
+		// // Test currently failing due to lack of style awareness. Currently we always add a blankline after
+		// // the env block.
+		// // Once proper behavior is implemented, enable this test.
+		// // {
+		// // 	name:             "Keep style if file doesnt use blank lines between blocks",
+		// // 	inputFilepath:    "noLineBreaksBetweenBlocks.yaml",
+		// // 	expectedFilepath: "noLineBreaksBetweenBlocks_fixed.yaml",
+		// // },
+		// {
+		// 	name:             "Ignore if user input regex is just part of a comment",
+		// 	inputFilepath:    "ignorePatternInsideComments.yaml",
+		// 	expectedFilepath: "ignorePatternInsideComments.yaml",
+		// },
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			inputFile := checker.File{
-				Path: tt.inputFilepath,
-			}
+			file := tt.file
+			file.Path = path.Join("./testdata", file.Path)
 
-			expectedContent, err := os.ReadFile("./testdata/" + tt.expectedFilepath)
+			expectedDiff, err := parseDiffFile(tt.diffPath)
 			if err != nil {
-				t.Errorf("Couldn't read expected testfile. Error:\n%s", err)
+				t.Errorf("Couldn't read expected diff file. Error:\n%s", err)
 			}
 
-			inputContent, err := os.ReadFile("./testdata/" + tt.inputFilepath)
+			inputContent, err := os.ReadFile(file.Path)
 			if err != nil {
 				t.Errorf("Couldn't read input testfile. Error:\n%s", err)
 			}
 
-			output := GeneratePatch(inputFile, inputContent)
-			if diff := cmp.Diff(string(expectedContent[:]), output); diff != "" {
-				// Uncomment the line bellow when the script is fully implemented and the tests are adapted to
-				// the official input/output
-
-				// t.Errorf("mismatch (-want +got):\n%s", diff)
+			output := GeneratePatch(file, string(inputContent))
+			if diff := cmp.Diff(expectedDiff, output); diff != "" {
+				fmt.Println(output)
+				fmt.Println(expectedDiff)
+				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+// This function parses the diff file and makes a few changes necessary to make a
+// valid comparison with the output of GeneratePatch.
+//
+// For example, the following diff file created with `git diff`:
+//
+//	diff --git a/testdata/foo.yaml b/testdata/foo_fixed.yaml
+//	index 843d0c71..cced3454 100644
+//	--- a/testdata/foo.yaml
+//	+++ b/testdata/foo_fixed.yaml
+//	@@ -6,6 +6,9 @@ jobs:
+//	< ... the diff ... >
+//
+// becomes:
+//
+//	--- a/testdata/foo.yaml
+//	+++ b/testdata/foo_fixed.yaml
+//	@@ -6,6 +6,9 @@
+//	< ... the diff ... >
+//
+// Note that, despite the differences between our output and the official
+// `git diff`, our output is still valid and can be passed to
+// `patch -p1 < path/to/file.diff` to apply the fix to the workflow.
+func parseDiffFile(filepath string) (string, error) {
+	c, err := os.ReadFile(path.Join("./testdata", filepath))
+	if err != nil {
+		return "", err
+	}
+
+	// The real `git diff` includes multiple "headers" (`diff --git ...`, `index ...`)
+	// Our diff does not include these headers; it starts with the "in/out" headers of
+	// --- a/path/to/file
+	// +++ b/path/to/file
+	// We must therefore remove any previous headers from the `git diff`.
+	lines := strings.Split(string(c), "\n")
+	i := 0
+	var line string
+	for i, line = range lines {
+		if strings.HasPrefix(line, "--- ") {
+			break
+		}
+	}
+	content := strings.Join(lines[i:], "\n")
+
+	// The real `git diff` adds contents after the `@@` anchors (the text of the line on
+	// which the anchor is placed):
+	// 		i.e. `@@ 1,2 3,4 @@ jobs:`
+	// while ours does not
+	//		i.e. `@@ 1,2 3,4 @@`
+	// We must therefore remove that extra content to compare with our diff.
+	r := regexp.MustCompile(`(@@[ \d,+-]+@@).*`)
+	return r.ReplaceAllString(string(content), "$1"), nil
 }

--- a/probes/hasDangerousWorkflowScriptInjection/patch/testdata/realExample1.diff
+++ b/probes/hasDangerousWorkflowScriptInjection/patch/testdata/realExample1.diff
@@ -1,0 +1,23 @@
+diff --git a/testdata/realExample1.yaml b/testdata/realExample1_fixed.yaml
+index 843d0c71..cced3454 100644
+--- a/testdata/realExample1.yaml
++++ b/testdata/realExample1_fixed.yaml
+@@ -6,6 +6,9 @@ on:
+ 
+ permissions: read-all
+ 
++env:
++  COMMENT_BODY: ${{ github.event.comment.body }}
++
+ jobs:
+   benchmark-compare:
+     runs-on: ubuntu-latest
+@@ -39,7 +42,7 @@ jobs:
+ 
+       - name: Preparing benchmark for GitHub action
+         id: info
+-        run: yarn benchmarks prepare-for-github-action "${{github.event.comment.body}}"
++        run: yarn benchmarks prepare-for-github-action "$COMMENT_BODY"
+ 
+       - run: yarn benchmarks run-compare ${{steps.info.outputs.compareSha}} ${{steps.info.outputs.benchmarkTarget}}
+         id: benchmark


### PR DESCRIPTION
This adds a git-diff format patch to every script-injection finding.

The git-diff is generated using a dependency not currently used by Scorecard, which isn't great. Even worse, the project was recently **_archived_**. But it's the only way I could find to create a usable git-diff.

I'm now working on the logic to run the tests with this format.